### PR TITLE
Fix the typo in SAML chapter

### DIFF
--- a/topics/clients/client-oidc.adoc
+++ b/topics/clients/client-oidc.adoc
@@ -71,9 +71,6 @@ _bearer-only_::
   Bearer-only access type means that the application only allows bearer token requests.
   If this is turned on, this application cannot participate in browser logins.
 
-_direct access only_::
-       This switch is for clients that only use the  <<fake/../../sso-protocols/oidc.adoc#_oidc-auth-flows,Direct Access Grant>> protocol to obtain access tokens.
-
 *Root URL*
 
 If {{book.project.name}} uses any configured relative URLs, this value is prepended to them.

--- a/topics/sso-protocols/saml.adoc
+++ b/topics/sso-protocols/saml.adoc
@@ -56,7 +56,7 @@ You really don't need to know about this stuff, but it is a pretty clever trick.
 ECP stands for "Enhanced Client or Proxy", a SAML v.2.0 profile which allows for the exchange of SAML attributes outside the context of a web browser.
 This is used most often for REST or SOAP-based clients.
 
-====  {{book.project.name}} Server OIDC URI Endpoints
+====  {{book.project.name}} Server SAML URI Endpoints
 
 {{book.project.name}} really only has one endpoint for all SAML requests.
 


### PR DESCRIPTION
- URI in the title should be "Keycloak Server SAML URI Endpoints"
- Remove note about "Direct access only" switch as it doesn't exists anymore