### PR TITLE
Update documentation with changes from latest docbook

### DIFF
--- a/topics/MigrationFromOlderVersions.adoc
+++ b/topics/MigrationFromOlderVersions.adoc
@@ -60,6 +60,31 @@ The version specific section below will mention if any changes are required to a
 
 === Version specific migration
 
+==== Migrating to 1.9.5
+
+===== Default password hashing interval increased to 20K
+
+The default password hashing interval for new realms has been increased to 20K (from 1 previously). This change will have an impact
+on performance when users authenticate. For example with the old default (1) it takes less than 1 ms to hash a password, but with
+the new default (20K) the same operation can take 50-100 ms.
+
+==== Migrating to 1.9.3
+
+===== Add User script renamed
+
+The script to add admin users to Keycloak has been renamed to `add-user-keycloak`.
+
+==== Migrating to 1.9.2
+
+===== Adapter option auth-server-url-for-backend-requests removed
+
+We've removed the option auth-server-url-for-backend-requests as there were issues in some scenarios when it was used. In more details,
+it was possible to access the Keycloak server from 2 different contexts (internal and external), which was causing issues in token validations etc.
+
+If you still want to use the optimization of network, which this option provided (avoid the application to send backchannel requests
+through loadbalancer but send them to local Keycloak server directly) you may need to handle it at hosts configuration (DNS) level.
+
+
 ==== Migrating to 1.9.0
 
 ===== Themes and providers directory moved

--- a/topics/export-import.adoc
+++ b/topics/export-import.adoc
@@ -68,7 +68,7 @@ Other available options are:
   * SAME_FILE - All users will be exported to same file but different from the realm file. (The result will be a file like "foo-realm.json" with realm data and "foo-users.json" with users.)                        
 
 -Dkeycloak.migration.usersPerFile::
-  This property can be used to specify the number of users per file (and also per DB transaction). It's 50 by default.
+  This property is used to specify the number of users per file (and also per DB transaction). It's 50 by default.
   It's used only if usersExportStrategy is DIFFERENT_FILES 
 
 -Dkeycloak.migration.strategy::

--- a/topics/export-import.adoc
+++ b/topics/export-import.adoc
@@ -21,7 +21,12 @@ If you are importing files which were previously exported, the files already fol
 * {REALM_NAME}-users-{INDEX}.json, such as "acme-roadrunner-affairs-users-0.json" for the first users file of the realm named "acme-roadrunner-affairs"        
 
 If you export to a directory, you can also specify the number of users that will be stored in each JSON file.
-So if you have very large number of users in your database, you likely don't want to import them into single file as the file might be very big.
+
+NOTE: If you have bigger amount of users in your database (500 or more), it's highly recommended to export into directory rather
+      than to single file. Exporting into single file may lead to the very big file. Also the directory provider is using separate transaction for each "page" (file with users),
+      which leads to much better performance.
+      Default count of users per file (and transaction) is 50, which showed us best performance, but you have possibility to override (See below).
+      Exporting to single file is using one transaction per whole export and one per whole import, which results in bad performance with large amount of users.
 
 To export into unencrypted directory you can use: 
 
@@ -63,7 +68,7 @@ Other available options are:
   * SAME_FILE - All users will be exported to same file but different from the realm file. (The result will be a file like "foo-realm.json" with realm data and "foo-users.json" with users.)                        
 
 -Dkeycloak.migration.usersPerFile::
-  This property is used to specify the number of users per file (and also per DB transaction). It's 5000 by default.
+  This property can be used to specify the number of users per file (and also per DB transaction). It's 50 by default.
   It's used only if usersExportStrategy is DIFFERENT_FILES 
 
 -Dkeycloak.migration.strategy::


### PR DESCRIPTION
- Export/import documentation for KEYCLOAK-2413
- Migration docs for migration to 1.9.2 , 1.9.3 and 1.9.5