### PR TITLE
Removal of workaround

### DIFF
--- a/topics/user-federation/sssd.adoc
+++ b/topics/user-federation/sssd.adoc
@@ -154,17 +154,8 @@ There's an RPM for this library https://github.com/keycloak/libunix-dbus-java/re
 
 {% endif %}
 
-{% if book.product %}
-
-You have to install the RPM for this library and create a symbolic link, before enabling SSSD Federation provider:
-
-  $ sudo yum install rh-sso7-libunix-dbus-java.x86_64.rpm
-  $ ln -s /opt/rh/rh-sso7/root/usr/lib64/libunix_dbus_java.so.0.0.8 /usr/lib64/
-
-{% endif %}
-
-
 For authentication with PAM {{book.project.name}} uses JNA under the covers. Please make ensure you have this package installed:
+
   $ sudo yum install jna
 
 After the installation, all you have to do is to configure a federated SSSD store, go to the Admin Console. Click on the User Federation left menu option. When you get to this page there is an Add Provider select box. You should see `sssd` within this list. Selecting `sssd` will bring you to the `sssd` configuration page and save it.


### PR DESCRIPTION
Because we merged [KEYCLOAK-4085](https://issues.jboss.org/browse/KEYCLOAK-4085) such workaround is no longer needed.

But I believe that this change only make sense for 2.5.0.Final, because it affects the docs of 7.1.0.ER3.